### PR TITLE
Add Get-MonitorInput and Set-MonitorInput cmdlets

### DIFF
--- a/Docs/Get-MonitorInput.md
+++ b/Docs/Get-MonitorInput.md
@@ -1,0 +1,73 @@
+---
+external help file: MonitorConfig.dll-Help.xml
+Module Name: MonitorConfig
+online version:
+schema: 2.0.0
+---
+
+# Get-MonitorInput
+
+## SYNOPSIS
+Gets the currently active input source on the specified monitors.
+
+## SYNTAX
+
+```
+Get-MonitorInput -Monitor <VCPMonitor[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads VCP code 0x60 (Input Select) on the specified monitor(s) and returns a
+`MonitorInputInfo` object with both the raw value and, when it matches an
+MCCS-spec input, the typed `CurrentSource`. Vendor-specific inputs (USB-C and
+similar) report the raw value with `CurrentSource` left null.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-Monitor | Get-MonitorInput
+
+CurrentValue CurrentSource
+------------ -------------
+          17 Hdmi1
+          17 Hdmi1
+```
+
+### Example 2
+```powershell
+PS C:\> Get-Monitor -Primary | Get-MonitorInput | Select-Object -ExpandProperty CurrentSource
+Hdmi1
+```
+
+## PARAMETERS
+
+### -Monitor
+The VCP-controlled monitor(s) to read the input source from.
+Internal panels that are managed via WMI don't expose an input source.
+
+```yaml
+Type: VCPMonitor[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### MartinGC94.MonitorConfig.API.VCP.VCPMonitor[]
+
+## OUTPUTS
+
+### MartinGC94.MonitorConfig.API.VCP.MonitorInputInfo
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Get-MonitorInput.md
+++ b/Docs/Get-MonitorInput.md
@@ -17,10 +17,13 @@ Get-MonitorInput -Monitor <VCPMonitor[]> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Reads VCP code 0x60 (Input Select) on the specified monitor(s) and returns a
-`MonitorInputInfo` object with both the raw value and, when it matches an
-MCCS-spec input, the typed `CurrentSource`. Vendor-specific inputs (USB-C and
-similar) report the raw value with `CurrentSource` left null.
+Reads VCP code 0x60 (Input Select) on the specified monitor(s) and returns a `MonitorInputInfo` object with:
+
+- `CurrentValue` — the raw VCP value currently active.
+
+- `CurrentSource` — the typed `MonitorInputSource` when the raw value matches an MCCS-spec input; null for vendor-specific values (USB-C and similar).
+
+- `PossibleValues` — the raw byte values the monitor advertises for VCP 0x60 in its DDC/CI capability string. Null when the capability string is unavailable or doesn't list VCP 0x60.
 
 ## EXAMPLES
 
@@ -28,10 +31,10 @@ similar) report the raw value with `CurrentSource` left null.
 ```powershell
 PS C:\> Get-Monitor | Get-MonitorInput
 
-CurrentValue CurrentSource
------------- -------------
-          17 Hdmi1
-          17 Hdmi1
+CurrentValue CurrentSource PossibleValues
+------------ ------------- --------------
+          17 Hdmi1         {15, 17, 27}
+          17 Hdmi1         {15, 17, 27}
 ```
 
 ### Example 2
@@ -39,6 +42,25 @@ CurrentValue CurrentSource
 PS C:\> Get-Monitor -Primary | Get-MonitorInput | Select-Object -ExpandProperty CurrentSource
 Hdmi1
 ```
+
+### Example 3
+```powershell
+PS C:\> Get-Monitor -Primary | Get-MonitorInput | ForEach-Object {
+>>     $_.PossibleValues | ForEach-Object {
+>>         if ([Enum]::IsDefined([MartinGC94.MonitorConfig.API.VCP.MonitorInputSource], [byte]$_)) {
+>>             [MartinGC94.MonitorConfig.API.VCP.MonitorInputSource]$_
+>>         } else {
+>>             '0x{0:X2}' -f $_
+>>         }
+>>     }
+>> }
+DisplayPort1
+Hdmi1
+0x1B
+```
+
+Maps `PossibleValues` to friendly names where possible, falling back to hex for
+vendor-specific values.
 
 ## PARAMETERS
 

--- a/Docs/Set-MonitorInput.md
+++ b/Docs/Set-MonitorInput.md
@@ -14,7 +14,7 @@ Sets the active input source on the specified monitors.
 
 ### BySource (Default)
 ```
-Set-MonitorInput -Monitor <VCPMonitor[]> [-Source] <MonitorInputSource> [<CommonParameters>]
+Set-MonitorInput -Monitor <VCPMonitor[]> [-Source] <String> [<CommonParameters>]
 ```
 
 ### ByValue
@@ -78,13 +78,20 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-The MCCS-spec input source to switch to.
+The MCCS-spec input source to switch to. Accepted values:
+Vga1, Vga2, Dvi1, Dvi2, Composite1, Composite2, SVideo1, SVideo2,
+Tuner1, Tuner2, Tuner3, Component1, Component2, Component3,
+DisplayPort1, DisplayPort2, Hdmi1, Hdmi2.
+
+When the -Monitor parameter is also bound, tab completion filters this
+list to the values that monitor advertises in its DDC/CI capability
+string. For inputs that aren't in the MCCS spec (e.g. USB-C), use the
+-Value parameter instead.
 
 ```yaml
-Type: MonitorInputSource
+Type: String
 Parameter Sets: BySource
 Aliases:
-Accepted values: Vga1, Vga2, Dvi1, Dvi2, Composite1, Composite2, SVideo1, SVideo2, Tuner1, Tuner2, Tuner3, Component1, Component2, Component3, DisplayPort1, DisplayPort2, Hdmi1, Hdmi2
 
 Required: True
 Position: 1

--- a/Docs/Set-MonitorInput.md
+++ b/Docs/Set-MonitorInput.md
@@ -12,22 +12,17 @@ Sets the active input source on the specified monitors.
 
 ## SYNTAX
 
-### BySource (Default)
 ```
-Set-MonitorInput -Monitor <VCPMonitor[]> [-Source] <String> [<CommonParameters>]
-```
-
-### ByValue
-```
-Set-MonitorInput -Monitor <VCPMonitor[]> [-Value] <UInt32> [<CommonParameters>]
+Set-MonitorInput -Monitor <VCPMonitor[]> [-Source] <UInt32> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Sets VCP code 0x60 (Input Select) on the specified monitor(s).
 
-Use the `-Source` parameter for MCCS-spec values (DisplayPort1, Hdmi1, etc.).
-Use the `-Value` parameter for vendor-specific inputs that aren't in the MCCS
-spec (some monitors expose USB-C and other inputs at non-standard codes).
+The `-Source` parameter accepts either a friendly name from the MCCS spec
+(DisplayPort1, Hdmi1, etc.) or a raw numeric value such as `0x1B` for
+vendor-specific inputs that aren't in the MCCS spec (some monitors expose
+USB-C and other inputs at non-standard codes).
 
 After the command runs, the monitor switches to the requested input. If the
 calling host is connected through the input being switched away from, it will
@@ -52,7 +47,7 @@ Switches a specific monitor to HDMI1.
 
 ### Example 3
 ```powershell
-PS C:\> Get-Monitor -Primary | Set-MonitorInput -Value 0x1B
+PS C:\> Get-Monitor -Primary | Set-MonitorInput -Source 0x1B
 ```
 
 Switches the primary monitor to a vendor-specific input that isn't in the
@@ -78,35 +73,18 @@ Accept wildcard characters: False
 ```
 
 ### -Source
-The MCCS-spec input source to switch to. Accepted values:
-Vga1, Vga2, Dvi1, Dvi2, Composite1, Composite2, SVideo1, SVideo2,
+The input source to switch to. Accepts MCCS-spec friendly names
+(Vga1, Vga2, Dvi1, Dvi2, Composite1, Composite2, SVideo1, SVideo2,
 Tuner1, Tuner2, Tuner3, Component1, Component2, Component3,
-DisplayPort1, DisplayPort2, Hdmi1, Hdmi2.
+DisplayPort1, DisplayPort2, Hdmi1, Hdmi2) or a raw numeric value
+(e.g. `17`, `0x11`) for vendor-specific inputs such as USB-C.
 
-When the -Monitor parameter is also bound, tab completion filters this
-list to the values that monitor advertises in its DDC/CI capability
-string. For inputs that aren't in the MCCS spec (e.g. USB-C), use the
--Value parameter instead.
-
-```yaml
-Type: String
-Parameter Sets: BySource
-Aliases:
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Value
-A raw VCP value for input source. Useful for vendor-specific inputs
-(USB-C and others) that aren't in the MCCS standard list.
+When the -Monitor parameter is also bound, tab completion shows the
+values that monitor advertises in its DDC/CI capability string.
 
 ```yaml
 Type: UInt32
-Parameter Sets: ByValue
+Parameter Sets: (All)
 Aliases:
 
 Required: True

--- a/Docs/Set-MonitorInput.md
+++ b/Docs/Set-MonitorInput.md
@@ -1,0 +1,124 @@
+---
+external help file: MonitorConfig.dll-Help.xml
+Module Name: MonitorConfig
+online version:
+schema: 2.0.0
+---
+
+# Set-MonitorInput
+
+## SYNOPSIS
+Sets the active input source on the specified monitors.
+
+## SYNTAX
+
+### BySource (Default)
+```
+Set-MonitorInput -Monitor <VCPMonitor[]> [-Source] <MonitorInputSource> [<CommonParameters>]
+```
+
+### ByValue
+```
+Set-MonitorInput -Monitor <VCPMonitor[]> [-Value] <UInt32> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sets VCP code 0x60 (Input Select) on the specified monitor(s).
+
+Use the `-Source` parameter for MCCS-spec values (DisplayPort1, Hdmi1, etc.).
+Use the `-Value` parameter for vendor-specific inputs that aren't in the MCCS
+spec (some monitors expose USB-C and other inputs at non-standard codes).
+
+After the command runs, the monitor switches to the requested input. If the
+calling host is connected through the input being switched away from, it will
+lose the signal — the command itself succeeds either way as long as the
+DDC/CI write reached the monitor.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-Monitor | Set-MonitorInput -Source DisplayPort1
+```
+
+Switches every active monitor to DisplayPort1.
+
+### Example 2
+```powershell
+PS C:\> Get-Monitor -DeviceName \\.\DISPLAY2 | Set-MonitorInput -Source Hdmi1
+```
+
+Switches a specific monitor to HDMI1.
+
+### Example 3
+```powershell
+PS C:\> Get-Monitor -Primary | Set-MonitorInput -Value 0x1B
+```
+
+Switches the primary monitor to a vendor-specific input that isn't in the
+MCCS standard list (Dell P-series USB-C is `0x1B` for example).
+
+## PARAMETERS
+
+### -Monitor
+The VCP-controlled monitor(s) to set the input on.
+Internal panels that are managed via WMI cannot change input source and will
+be rejected by parameter binding.
+
+```yaml
+Type: VCPMonitor[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Source
+The MCCS-spec input source to switch to.
+
+```yaml
+Type: MonitorInputSource
+Parameter Sets: BySource
+Aliases:
+Accepted values: Vga1, Vga2, Dvi1, Dvi2, Composite1, Composite2, SVideo1, SVideo2, Tuner1, Tuner2, Tuner3, Component1, Component2, Component3, DisplayPort1, DisplayPort2, Hdmi1, Hdmi2
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+A raw VCP value for input source. Useful for vendor-specific inputs
+(USB-C and others) that aren't in the MCCS standard list.
+
+```yaml
+Type: UInt32
+Parameter Sets: ByValue
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### MartinGC94.MonitorConfig.API.VCP.VCPMonitor[]
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/PowerShellFormatFiles/MonitorConfigFormat.ps1xml
+++ b/PowerShellFormatFiles/MonitorConfigFormat.ps1xml
@@ -56,6 +56,46 @@
          </TableControl>
       </View>
       <View>
+         <Name>MonitorInputInfo</Name>
+         <ViewSelectedBy>
+            <TypeName>MartinGC94.MonitorConfig.API.VCP.MonitorInputInfo</TypeName>
+         </ViewSelectedBy>
+         <TableControl>
+            <TableHeaders>
+               <TableColumnHeader>
+                  <Label>CurrentValue</Label>
+                  <Alignment>right</Alignment>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>CurrentSource</Label>
+                  <Alignment>left</Alignment>
+               </TableColumnHeader>
+               <TableColumnHeader>
+                  <Label>PossibleValues</Label>
+                  <Alignment>left</Alignment>
+               </TableColumnHeader>
+            </TableHeaders>
+            <TableRowEntries>
+               <TableRowEntry>
+                  <TableColumnItems>
+                     <TableColumnItem>
+                        <PropertyName>CurrentValue</PropertyName>
+                        <Alignment>right</Alignment>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>CurrentSource</PropertyName>
+                        <Alignment>left</Alignment>
+                     </TableColumnItem>
+                     <TableColumnItem>
+                        <PropertyName>PossibleValues</PropertyName>
+                        <Alignment>left</Alignment>
+                     </TableColumnItem>
+                  </TableColumnItems>
+               </TableRowEntry>
+            </TableRowEntries>
+         </TableControl>
+      </View>
+      <View>
          <Name>ParsedVCPCode</Name>
          <ViewSelectedBy>
             <TypeName>MartinGC94.MonitorConfig.API.VCP.ParsedVCPCode</TypeName>

--- a/Release notes.txt
+++ b/Release notes.txt
@@ -1,8 +1,10 @@
 2.2.0:
     Added Get-MonitorInput and Set-MonitorInput cmdlets for reading and writing
-    VCP code 0x60 (Input Select). Set-MonitorInput accepts either a typed
-    MonitorInputSource (MCCS-spec values such as DisplayPort1, Hdmi1) or a raw
-    UInt32 Value for vendor-specific inputs (e.g. USB-C).
+    VCP code 0x60 (Input Select). Set-MonitorInput's -Source parameter accepts
+    either a friendly name (Hdmi1, DisplayPort1, etc.) or a raw numeric value
+    such as 0x1B for vendor-specific inputs (e.g. USB-C). Get-MonitorInput
+    returns the current value alongside the values the monitor advertises in
+    its capability string.
 2.1.0:
     Updated the errors to be more descriptive when failing to fetch monitors.
 2.0:

--- a/Release notes.txt
+++ b/Release notes.txt
@@ -1,3 +1,8 @@
+2.2.0:
+    Added Get-MonitorInput and Set-MonitorInput cmdlets for reading and writing
+    VCP code 0x60 (Input Select). Set-MonitorInput accepts either a typed
+    MonitorInputSource (MCCS-spec values such as DisplayPort1, Hdmi1) or a raw
+    UInt32 Value for vendor-specific inputs (e.g. USB-C).
 2.1.0:
     Updated the errors to be more descriptive when failing to fetch monitors.
 2.0:

--- a/src/MonitorConfig/API/MonitorInputCompleter.cs
+++ b/src/MonitorConfig/API/MonitorInputCompleter.cs
@@ -1,0 +1,186 @@
+using MartinGC94.MonitorConfig.API.VCP;
+using MartinGC94.MonitorConfig.Commands;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace MartinGC94.MonitorConfig.API
+{
+    /// <summary>
+    /// Completer for Set-MonitorInput -Source. When the -Monitor parameter
+    /// is bound (by object or device-name string), the suggestions are
+    /// filtered to MCCS-spec values that monitor advertises in its
+    /// capability string. Falls back to the full enum if the monitor is
+    /// unknown or advertises no MCCS-mapped value.
+    /// </summary>
+    internal sealed class MonitorInputSourceCompleter : IArgumentCompleter
+    {
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            var pattern = WildcardPattern.Get((wordToComplete ?? string.Empty).Trim('\'', '"') + "*", WildcardOptions.IgnoreCase);
+            byte[] supported = MonitorInputCompleterHelper.GetSupportedValuesFromBoundMonitor(fakeBoundParameters);
+
+            var allSources = (MonitorInputSource[])Enum.GetValues(typeof(MonitorInputSource));
+            MonitorInputSource[] suggestions = allSources;
+            if (supported != null && supported.Length > 0)
+            {
+                var supportedSet = new HashSet<byte>(supported);
+                var filtered = Array.FindAll(allSources, s => supportedSet.Contains((byte)s));
+                if (filtered.Length > 0)
+                {
+                    suggestions = filtered;
+                }
+            }
+
+            foreach (var source in suggestions)
+            {
+                string name = source.ToString();
+                if (pattern.IsMatch(name))
+                {
+                    string tooltip = string.Format(CultureInfo.InvariantCulture, "0x{0:X2} ({1})", (byte)source, name);
+                    yield return new CompletionResult(name, name, CompletionResultType.ParameterValue, tooltip);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Completer for Set-MonitorInput -Value. When the -Monitor parameter is
+    /// bound, suggestions come from the monitor's advertised values for VCP
+    /// 0x60 (this is the right list for discovering vendor-specific inputs
+    /// such as USB-C, which is not in the MCCS spec). Falls back to the
+    /// MCCS values when the monitor is unknown.
+    /// </summary>
+    internal sealed class MonitorInputValueCompleter : IArgumentCompleter
+    {
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            var pattern = WildcardPattern.Get((wordToComplete ?? string.Empty).Trim('\'', '"') + "*", WildcardOptions.IgnoreCase);
+            byte[] supported = MonitorInputCompleterHelper.GetSupportedValuesFromBoundMonitor(fakeBoundParameters);
+
+            byte[] toSuggest;
+            if (supported != null && supported.Length > 0)
+            {
+                toSuggest = supported;
+            }
+            else
+            {
+                var allSources = (MonitorInputSource[])Enum.GetValues(typeof(MonitorInputSource));
+                toSuggest = Array.ConvertAll(allSources, s => (byte)s);
+            }
+
+            foreach (byte value in toSuggest)
+            {
+                string asHex = string.Format(CultureInfo.InvariantCulture, "0x{0:X2}", value);
+                string asDec = value.ToString(CultureInfo.InvariantCulture);
+                string sourceName = Enum.IsDefined(typeof(MonitorInputSource), value)
+                    ? ((MonitorInputSource)value).ToString()
+                    : "vendor-specific";
+                string tooltip = string.Format(CultureInfo.InvariantCulture, "{0} ({1}) - {2}", asHex, asDec, sourceName);
+
+                if (pattern.IsMatch(asHex) || pattern.IsMatch(asDec) || pattern.IsMatch(sourceName))
+                {
+                    yield return new CompletionResult(asHex, tooltip, CompletionResultType.ParameterValue, tooltip);
+                }
+            }
+        }
+    }
+
+    internal static class MonitorInputCompleterHelper
+    {
+        public static byte[] GetSupportedValuesFromBoundMonitor(IDictionary fakeBoundParameters)
+        {
+            VCPMonitor monitor = ResolveFirstVCPMonitor(fakeBoundParameters);
+            if (monitor == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                var caps = ParsedCapabilityString.ParseCapabilityString(monitor.GetCapabilitiesString());
+                if (caps.VCPCodes == null)
+                {
+                    return null;
+                }
+                foreach (var vcp in caps.VCPCodes)
+                {
+                    if (vcp.VCPCode == KnownVcpCodes.InputSelect)
+                    {
+                        return vcp.ValidValues;
+                    }
+                }
+            }
+            catch
+            {
+                // Best-effort completion; never throw out of CompleteArgument.
+            }
+
+            return null;
+        }
+
+        private static VCPMonitor ResolveFirstVCPMonitor(IDictionary fakeBoundParameters)
+        {
+            if (fakeBoundParameters == null || !fakeBoundParameters.Contains("Monitor"))
+            {
+                return null;
+            }
+
+            object raw = fakeBoundParameters["Monitor"];
+            object unwrapped = raw is PSObject pso ? pso.BaseObject : raw;
+
+            if (unwrapped is VCPMonitor direct)
+            {
+                return direct;
+            }
+
+            var deviceNames = new List<string>();
+            if (unwrapped is string s)
+            {
+                deviceNames.Add(s);
+            }
+            else if (unwrapped is IEnumerable enumerable && !(unwrapped is string))
+            {
+                foreach (var item in enumerable)
+                {
+                    object unwrappedItem = item is PSObject p ? p.BaseObject : item;
+                    if (unwrappedItem is VCPMonitor vcpItem)
+                    {
+                        return vcpItem;
+                    }
+                    if (unwrappedItem is string str)
+                    {
+                        deviceNames.Add(str);
+                    }
+                }
+            }
+
+            if (deviceNames.Count == 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                var cmd = new GetMonitorCommand { DeviceName = deviceNames.ToArray() };
+                foreach (var item in cmd.Invoke())
+                {
+                    object unwrappedItem = item is PSObject p ? p.BaseObject : item;
+                    if (unwrappedItem is VCPMonitor vcp)
+                    {
+                        return vcp;
+                    }
+                }
+            }
+            catch
+            {
+                // Best-effort.
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/MonitorConfig/API/MonitorInputCompleter.cs
+++ b/src/MonitorConfig/API/MonitorInputCompleter.cs
@@ -10,80 +10,62 @@ using System.Management.Automation.Language;
 namespace MartinGC94.MonitorConfig.API
 {
     /// <summary>
-    /// Completer for Set-MonitorInput -Source. When the -Monitor parameter
-    /// is bound (by object or device-name string), the suggestions are
-    /// filtered to MCCS-spec values that monitor advertises in its
-    /// capability string. Falls back to the full enum if the monitor is
-    /// unknown or advertises no MCCS-mapped value.
+    /// Completer for Set-MonitorInput -Source. When the -Monitor parameter is
+    /// bound (by object or device-name string), suggestions come from the
+    /// monitor's advertised values for VCP 0x60. MCCS-spec values are offered
+    /// as friendly names (Hdmi1, DisplayPort1, etc.) and vendor-specific
+    /// values (e.g. USB-C) are offered as hex. Falls back to the full MCCS
+    /// list when no monitor is bound.
     /// </summary>
     internal sealed class MonitorInputSourceCompleter : IArgumentCompleter
     {
         public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
         {
             var pattern = WildcardPattern.Get((wordToComplete ?? string.Empty).Trim('\'', '"') + "*", WildcardOptions.IgnoreCase);
-            byte[] supported = MonitorInputCompleterHelper.GetSupportedValuesFromBoundMonitor(fakeBoundParameters);
+            byte[] supported = MonitorInputCompleterHelper.TryGetSupportedValuesFromBoundMonitor(fakeBoundParameters);
 
-            var allSources = (MonitorInputSource[])Enum.GetValues(typeof(MonitorInputSource));
-            MonitorInputSource[] suggestions = allSources;
             if (supported != null && supported.Length > 0)
             {
-                var supportedSet = new HashSet<byte>(supported);
-                var filtered = Array.FindAll(allSources, s => supportedSet.Contains((byte)s));
-                if (filtered.Length > 0)
+                foreach (byte value in supported)
                 {
-                    suggestions = filtered;
+                    foreach (var result in BuildCompletions(value, pattern))
+                    {
+                        yield return result;
+                    }
                 }
+
+                yield break;
             }
 
-            foreach (var source in suggestions)
+            foreach (MonitorInputSource source in (MonitorInputSource[])Enum.GetValues(typeof(MonitorInputSource)))
             {
-                string name = source.ToString();
-                if (pattern.IsMatch(name))
+                foreach (var result in BuildCompletions((byte)source, pattern))
                 {
-                    string tooltip = string.Format(CultureInfo.InvariantCulture, "0x{0:X2} ({1})", (byte)source, name);
-                    yield return new CompletionResult(name, name, CompletionResultType.ParameterValue, tooltip);
+                    yield return result;
                 }
             }
         }
-    }
 
-    /// <summary>
-    /// Completer for Set-MonitorInput -Value. When the -Monitor parameter is
-    /// bound, suggestions come from the monitor's advertised values for VCP
-    /// 0x60 (this is the right list for discovering vendor-specific inputs
-    /// such as USB-C, which is not in the MCCS spec). Falls back to the
-    /// MCCS values when the monitor is unknown.
-    /// </summary>
-    internal sealed class MonitorInputValueCompleter : IArgumentCompleter
-    {
-        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        private static IEnumerable<CompletionResult> BuildCompletions(byte value, WildcardPattern pattern)
         {
-            var pattern = WildcardPattern.Get((wordToComplete ?? string.Empty).Trim('\'', '"') + "*", WildcardOptions.IgnoreCase);
-            byte[] supported = MonitorInputCompleterHelper.GetSupportedValuesFromBoundMonitor(fakeBoundParameters);
+            string hex = string.Format(CultureInfo.InvariantCulture, "0x{0:X2}", value);
+            string dec = value.ToString(CultureInfo.InvariantCulture);
 
-            byte[] toSuggest;
-            if (supported != null && supported.Length > 0)
+            if (Enum.IsDefined(typeof(MonitorInputSource), value))
             {
-                toSuggest = supported;
+                string name = ((MonitorInputSource)value).ToString();
+                string tooltip = string.Format(CultureInfo.InvariantCulture, "{0} ({1}) - {2}", hex, dec, name);
+                if (pattern.IsMatch(name) || pattern.IsMatch(hex) || pattern.IsMatch(dec))
+                {
+                    yield return new CompletionResult(name, name, CompletionResultType.ParameterValue, tooltip);
+                }
             }
             else
             {
-                var allSources = (MonitorInputSource[])Enum.GetValues(typeof(MonitorInputSource));
-                toSuggest = Array.ConvertAll(allSources, s => (byte)s);
-            }
-
-            foreach (byte value in toSuggest)
-            {
-                string asHex = string.Format(CultureInfo.InvariantCulture, "0x{0:X2}", value);
-                string asDec = value.ToString(CultureInfo.InvariantCulture);
-                string sourceName = Enum.IsDefined(typeof(MonitorInputSource), value)
-                    ? ((MonitorInputSource)value).ToString()
-                    : "vendor-specific";
-                string tooltip = string.Format(CultureInfo.InvariantCulture, "{0} ({1}) - {2}", asHex, asDec, sourceName);
-
-                if (pattern.IsMatch(asHex) || pattern.IsMatch(asDec) || pattern.IsMatch(sourceName))
+                string tooltip = string.Format(CultureInfo.InvariantCulture, "{0} ({1}) - vendor-specific", hex, dec);
+                if (pattern.IsMatch(hex) || pattern.IsMatch(dec))
                 {
-                    yield return new CompletionResult(asHex, tooltip, CompletionResultType.ParameterValue, tooltip);
+                    yield return new CompletionResult(hex, hex, CompletionResultType.ParameterValue, tooltip);
                 }
             }
         }
@@ -91,9 +73,8 @@ namespace MartinGC94.MonitorConfig.API
 
     internal static class MonitorInputCompleterHelper
     {
-        public static byte[] GetSupportedValuesFromBoundMonitor(IDictionary fakeBoundParameters)
+        public static byte[] TryGetSupportedValues(VCPMonitor monitor)
         {
-            VCPMonitor monitor = ResolveFirstVCPMonitor(fakeBoundParameters);
             if (monitor == null)
             {
                 return null;
@@ -116,7 +97,109 @@ namespace MartinGC94.MonitorConfig.API
             }
             catch
             {
-                // Best-effort completion; never throw out of CompleteArgument.
+                // Best-effort lookup; never throw out of completion or out of the get-cmdlet's discovery path.
+            }
+
+            return null;
+        }
+
+        private static readonly object _capsCacheLock = new object();
+        private static readonly Dictionary<string, byte[]> _capsCache = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        private static HashSet<string> _capsCacheDisplaySnapshot;
+
+        /// <summary>
+        /// Returns the current set of logical-display device names via a cheap Win32
+        /// enumeration. Used as a fingerprint to detect monitor hot-plug between cache
+        /// reads — any add/remove changes the set, so cache entries get invalidated
+        /// automatically without a wall-clock TTL.
+        /// </summary>
+        internal static HashSet<string> SnapshotLogicalDisplayNames()
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var d in LogicalDisplay.GetMatchingLogicalDisplays(null))
+            {
+                if (!string.IsNullOrEmpty(d.DeviceName))
+                {
+                    set.Add(d.DeviceName);
+                }
+            }
+            return set;
+        }
+
+        /// <summary>
+        /// Completer-side variant: caches the parsed VCP 0x60 ValidValues by a key derived
+        /// from the bound -Monitor so repeated Tab presses don't reissue DDC/CI capability
+        /// reads. The cache lives for the lifetime of the PowerShell session and is
+        /// invalidated when the set of logical displays changes (monitor hot-plug). The
+        /// cmdlet path uses the uncached <see cref="TryGetSupportedValues"/>.
+        /// </summary>
+        public static byte[] TryGetSupportedValuesFromBoundMonitor(IDictionary fakeBoundParameters)
+        {
+            string cacheKey = TryBuildCacheKey(fakeBoundParameters);
+            if (cacheKey == null)
+            {
+                return null;
+            }
+
+            HashSet<string> currentSnapshot = SnapshotLogicalDisplayNames();
+
+            lock (_capsCacheLock)
+            {
+                if (_capsCacheDisplaySnapshot != null && !_capsCacheDisplaySnapshot.SetEquals(currentSnapshot))
+                {
+                    _capsCache.Clear();
+                }
+                _capsCacheDisplaySnapshot = currentSnapshot;
+
+                if (_capsCache.TryGetValue(cacheKey, out byte[] cached))
+                {
+                    return cached;
+                }
+            }
+
+            byte[] values = TryGetSupportedValues(ResolveFirstVCPMonitor(fakeBoundParameters));
+
+            lock (_capsCacheLock)
+            {
+                _capsCache[cacheKey] = values;
+            }
+            return values;
+        }
+
+        private static string TryBuildCacheKey(IDictionary fakeBoundParameters)
+        {
+            if (fakeBoundParameters == null || !fakeBoundParameters.Contains("Monitor"))
+            {
+                return null;
+            }
+
+            object raw = fakeBoundParameters["Monitor"];
+            object unwrapped = raw is PSObject pso ? pso.BaseObject : raw;
+
+            if (unwrapped is VCPMonitor direct && !string.IsNullOrEmpty(direct.InstanceName))
+            {
+                return "vcp:" + direct.InstanceName;
+            }
+
+            if (unwrapped is string s && !string.IsNullOrEmpty(s))
+            {
+                return "str:" + s;
+            }
+
+            if (unwrapped is IEnumerable enumerable && !(unwrapped is string))
+            {
+                foreach (var item in enumerable)
+                {
+                    object unwrappedItem = item is PSObject p ? p.BaseObject : item;
+                    if (unwrappedItem is VCPMonitor v && !string.IsNullOrEmpty(v.InstanceName))
+                    {
+                        return "vcp:" + v.InstanceName;
+                    }
+                    if (unwrappedItem is string str && !string.IsNullOrEmpty(str))
+                    {
+                        return "str:" + str;
+                    }
+                }
             }
 
             return null;
@@ -165,7 +248,10 @@ namespace MartinGC94.MonitorConfig.API
 
             try
             {
-                var cmd = new GetMonitorCommand { DeviceName = deviceNames.ToArray() };
+                var cmd = new GetMonitorCommand()
+                {
+                    DeviceName = deviceNames.ToArray()
+                };
                 foreach (var item in cmd.Invoke())
                 {
                     object unwrappedItem = item is PSObject p ? p.BaseObject : item;

--- a/src/MonitorConfig/API/VCP/KnownVcpCodes.cs
+++ b/src/MonitorConfig/API/VCP/KnownVcpCodes.cs
@@ -5,6 +5,7 @@
     /// </summary>
     internal sealed class KnownVcpCodes
     {
+        public const byte InputSelect = 0x60;
         public const byte ColorSaturation = 0x8A;
         public const byte RedSaturation = 0x59;
         public const byte YellowSaturation = 0x5A;

--- a/src/MonitorConfig/API/VCP/MonitorInputInfo.cs
+++ b/src/MonitorConfig/API/VCP/MonitorInputInfo.cs
@@ -3,16 +3,19 @@ using System;
 namespace MartinGC94.MonitorConfig.API.VCP
 {
     /// <summary>
-    /// Result type for Get-MonitorInput. CurrentSource is set when the raw
-    /// CurrentValue matches one of the MCCS-spec values defined by
+    /// Result type for Get-MonitorInput. <see cref="CurrentSource"/> is set when the raw
+    /// <see cref="CurrentValue"/> matches one of the MCCS-spec values defined by
     /// <see cref="MonitorInputSource"/>; for vendor-specific values it is null.
+    /// <see cref="PossibleValues"/> is populated from the monitor's DDC/CI capability
+    /// string (VCP 0x60) when available, and is null otherwise.
     /// </summary>
     public sealed class MonitorInputInfo
     {
         public uint CurrentValue { get; }
         public MonitorInputSource? CurrentSource { get; }
+        public byte[] PossibleValues { get; }
 
-        internal MonitorInputInfo(uint rawCurrentValue)
+        internal MonitorInputInfo(uint rawCurrentValue, byte[] possibleValues)
         {
             // Per MCCS 2.2a, VCP 0x60 (Input Select) is a single byte and the
             // value comes back in the SL byte of the DDC reply packet (= low
@@ -24,6 +27,7 @@ namespace MartinGC94.MonitorConfig.API.VCP
             CurrentSource = Enum.IsDefined(typeof(MonitorInputSource), sl)
                 ? (MonitorInputSource?)(MonitorInputSource)sl
                 : null;
+            PossibleValues = possibleValues;
         }
     }
 }

--- a/src/MonitorConfig/API/VCP/MonitorInputInfo.cs
+++ b/src/MonitorConfig/API/VCP/MonitorInputInfo.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace MartinGC94.MonitorConfig.API.VCP
+{
+    /// <summary>
+    /// Result type for Get-MonitorInput. CurrentSource is set when the raw
+    /// CurrentValue matches one of the MCCS-spec values defined by
+    /// <see cref="MonitorInputSource"/>; for vendor-specific values it is null.
+    /// </summary>
+    public sealed class MonitorInputInfo
+    {
+        public uint CurrentValue { get; }
+        public MonitorInputSource? CurrentSource { get; }
+
+        internal MonitorInputInfo(uint rawCurrentValue)
+        {
+            // Per MCCS 2.2a, VCP 0x60 (Input Select) is a single byte and the
+            // value comes back in the SL byte of the DDC reply packet (= low
+            // byte of the DWORD here). Some monitors duplicate the byte into
+            // both SH and SL (so a SET of 0x11 reads back as 0x1111). Mask to
+            // SL so the result compares cleanly with what was passed to Set.
+            byte sl = (byte)(rawCurrentValue & 0xFF);
+            CurrentValue = sl;
+            CurrentSource = Enum.IsDefined(typeof(MonitorInputSource), sl)
+                ? (MonitorInputSource?)(MonitorInputSource)sl
+                : null;
+        }
+    }
+}

--- a/src/MonitorConfig/API/VCP/MonitorInputSource.cs
+++ b/src/MonitorConfig/API/VCP/MonitorInputSource.cs
@@ -1,0 +1,29 @@
+namespace MartinGC94.MonitorConfig.API.VCP
+{
+    /// <summary>
+    /// Input source values defined by the MCCS spec for VCP code 0x60 (Input Select).
+    /// Vendors often add their own values outside this list (for example USB-C
+    /// inputs); use the -Value parameter on Set-MonitorInput for those.
+    /// </summary>
+    public enum MonitorInputSource : byte
+    {
+        Vga1 = 0x01,
+        Vga2 = 0x02,
+        Dvi1 = 0x03,
+        Dvi2 = 0x04,
+        Composite1 = 0x05,
+        Composite2 = 0x06,
+        SVideo1 = 0x07,
+        SVideo2 = 0x08,
+        Tuner1 = 0x09,
+        Tuner2 = 0x0A,
+        Tuner3 = 0x0B,
+        Component1 = 0x0C,
+        Component2 = 0x0D,
+        Component3 = 0x0E,
+        DisplayPort1 = 0x0F,
+        DisplayPort2 = 0x10,
+        Hdmi1 = 0x11,
+        Hdmi2 = 0x12,
+    }
+}

--- a/src/MonitorConfig/API/VCP/MonitorInputSourceArgTransformer.cs
+++ b/src/MonitorConfig/API/VCP/MonitorInputSourceArgTransformer.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace MartinGC94.MonitorConfig.API.VCP
+{
+    /// <summary>
+    /// Converts known input-source names (e.g. "Hdmi1") and hex strings
+    /// (e.g. "0x1B") to a uint VCP value. Anything else is passed through
+    /// for PowerShell to convert to uint.
+    /// </summary>
+    internal sealed class MonitorInputSourceArgTransformer : ArgumentTransformationAttribute
+    {
+        public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+        {
+            object unwrapped = inputData is PSObject psObj ? psObj.BaseObject : inputData;
+
+            if (unwrapped is string inputAsString)
+            {
+                string trimmed = inputAsString.Trim();
+                if (Enum.TryParse(trimmed, true, out MonitorInputSource parsed)
+                    && Enum.IsDefined(typeof(MonitorInputSource), parsed))
+                {
+                    return (uint)(byte)parsed;
+                }
+
+                if (trimmed.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                    && uint.TryParse(trimmed.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint hex))
+                {
+                    return hex;
+                }
+            }
+
+            return inputData;
+        }
+    }
+}

--- a/src/MonitorConfig/API/VCP/VCPMonitor.cs
+++ b/src/MonitorConfig/API/VCP/VCPMonitor.cs
@@ -66,9 +66,9 @@ namespace MartinGC94.MonitorConfig.API.VCP
             return new BrightnessInfo(brightnessLevel, minBrightness, maxBrightness);
         }
 
-        public MonitorInputInfo GetInputInfo()
+        public MonitorInputInfo GetInputInfo(byte[] possibleValues = null)
         {
-            return new MonitorInputInfo(GetVCPFeatureResponse(KnownVcpCodes.InputSelect).CurrentValue);
+            return new MonitorInputInfo(GetVCPFeatureResponse(KnownVcpCodes.InputSelect).CurrentValue, possibleValues);
         }
 
         public void SetInputSource(uint value)

--- a/src/MonitorConfig/API/VCP/VCPMonitor.cs
+++ b/src/MonitorConfig/API/VCP/VCPMonitor.cs
@@ -66,6 +66,16 @@ namespace MartinGC94.MonitorConfig.API.VCP
             return new BrightnessInfo(brightnessLevel, minBrightness, maxBrightness);
         }
 
+        public MonitorInputInfo GetInputInfo()
+        {
+            return new MonitorInputInfo(GetVCPFeatureResponse(KnownVcpCodes.InputSelect).CurrentValue);
+        }
+
+        public void SetInputSource(uint value)
+        {
+            SetVCPValue(KnownVcpCodes.InputSelect, value);
+        }
+
         public void DegaussMonitor()
         {
             if (!NativeMethods.DegaussMonitor(physicalMonitorHandle))

--- a/src/MonitorConfig/API/VCPDeviceNameCompleter.cs
+++ b/src/MonitorConfig/API/VCPDeviceNameCompleter.cs
@@ -1,0 +1,96 @@
+using MartinGC94.MonitorConfig.API.VCP;
+using MartinGC94.MonitorConfig.Commands;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace MartinGC94.MonitorConfig.API
+{
+    /// <summary>
+    /// Completer for the -Monitor parameter on cmdlets that require a VCP-capable
+    /// (DDC/CI) monitor. Only suggests displays whose physical monitor is exposed
+    /// as a VCPMonitor, so a Tab suggestion will always bind to a VCPMonitor[]
+    /// parameter without a type-conversion error. The list of VCP device names is
+    /// cached for the lifetime of the PowerShell session and invalidated when the
+    /// set of logical displays changes (monitor hot-plug), so users don't pay the
+    /// enumeration cost on every Tab press.
+    /// </summary>
+    internal sealed class VCPDeviceNameCompleter : IArgumentCompleter
+    {
+        private static readonly object _cacheLock = new object();
+        private static string[] _cachedNames;
+        private static HashSet<string> _cachedDisplaySnapshot;
+
+        public IEnumerable<CompletionResult> CompleteArgument(string commandName, string parameterName, string wordToComplete, CommandAst commandAst, IDictionary fakeBoundParameters)
+        {
+            string cleanWordToComplete = ((wordToComplete ?? string.Empty).Trim('\'', '"')) + "*";
+            var pattern = WildcardPattern.Get(cleanWordToComplete, WildcardOptions.IgnoreCase);
+
+            string[] names;
+            try
+            {
+                names = GetVCPDeviceNames();
+            }
+            catch
+            {
+                yield break;
+            }
+
+            foreach (string name in names)
+            {
+                if (pattern.IsMatch(name))
+                {
+                    yield return new CompletionResult(name, name, CompletionResultType.ParameterValue, name);
+                }
+            }
+        }
+
+        private static string[] GetVCPDeviceNames()
+        {
+            HashSet<string> currentSnapshot = MonitorInputCompleterHelper.SnapshotLogicalDisplayNames();
+
+            lock (_cacheLock)
+            {
+                if (_cachedNames != null
+                    && _cachedDisplaySnapshot != null
+                    && _cachedDisplaySnapshot.SetEquals(currentSnapshot))
+                {
+                    return _cachedNames;
+                }
+
+                var names = new List<string>();
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                var cmd = new GetMonitorCommand()
+                {
+                    DeviceName = new[] { "*" }
+                };
+                foreach (var item in cmd.Invoke())
+                {
+                    object unwrapped = item is PSObject pso ? pso.BaseObject : item;
+                    if (unwrapped is VCPMonitor vcp)
+                    {
+                        try
+                        {
+                            string name = vcp.LogicalDisplay?.DeviceName;
+                            if (!string.IsNullOrEmpty(name) && seen.Add(name))
+                            {
+                                names.Add(name);
+                            }
+                        }
+                        finally
+                        {
+                            // Release the physical-monitor handle; we only need the name.
+                            vcp.Dispose();
+                        }
+                    }
+                }
+
+                _cachedNames = names.ToArray();
+                _cachedDisplaySnapshot = currentSnapshot;
+                return _cachedNames;
+            }
+        }
+    }
+}

--- a/src/MonitorConfig/Commands/GetMonitorInputCommand.cs
+++ b/src/MonitorConfig/Commands/GetMonitorInputCommand.cs
@@ -12,7 +12,7 @@ namespace MartinGC94.MonitorConfig.Commands
     {
         #region parameters
         [MonitorArgTransformer()]
-        [ArgumentCompleter(typeof(DeviceNameCompleter))]
+        [ArgumentCompleter(typeof(VCPDeviceNameCompleter))]
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public VCPMonitor[] Monitor { get; set; }
         #endregion
@@ -21,9 +21,11 @@ namespace MartinGC94.MonitorConfig.Commands
         {
             foreach (VCPMonitor inputMonitor in Monitor)
             {
+                byte[] possibleValues = MonitorInputCompleterHelper.TryGetSupportedValues(inputMonitor);
+
                 try
                 {
-                    WriteObject(inputMonitor.GetInputInfo());
+                    WriteObject(inputMonitor.GetInputInfo(possibleValues));
                 }
                 catch (Win32Exception error)
                 {

--- a/src/MonitorConfig/Commands/GetMonitorInputCommand.cs
+++ b/src/MonitorConfig/Commands/GetMonitorInputCommand.cs
@@ -1,0 +1,39 @@
+using MartinGC94.MonitorConfig.API;
+using MartinGC94.MonitorConfig.API.VCP;
+using System;
+using System.ComponentModel;
+using System.Management.Automation;
+
+namespace MartinGC94.MonitorConfig.Commands
+{
+    [Cmdlet(VerbsCommon.Get, "MonitorInput")]
+    [OutputType(typeof(MonitorInputInfo))]
+    public sealed class GetMonitorInputCommand : Cmdlet
+    {
+        #region parameters
+        [MonitorArgTransformer()]
+        [ArgumentCompleter(typeof(DeviceNameCompleter))]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        public VCPMonitor[] Monitor { get; set; }
+        #endregion
+
+        protected override void ProcessRecord()
+        {
+            foreach (VCPMonitor inputMonitor in Monitor)
+            {
+                try
+                {
+                    WriteObject(inputMonitor.GetInputInfo());
+                }
+                catch (Win32Exception error)
+                {
+                    WriteError(new ErrorRecord(
+                        new Exception($"Failed to get input source due to error: {error.Message}", error),
+                        "GetInputError",
+                        Utils.GetErrorCategory(error),
+                        inputMonitor));
+                }
+            }
+        }
+    }
+}

--- a/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
+++ b/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
@@ -6,53 +6,28 @@ using System.Management.Automation;
 
 namespace MartinGC94.MonitorConfig.Commands
 {
-    [Cmdlet(VerbsCommon.Set, "MonitorInput", DefaultParameterSetName = "BySource")]
+    [Cmdlet(VerbsCommon.Set, "MonitorInput")]
     public sealed class SetMonitorInputCommand : PSCmdlet
     {
         #region parameters
         [MonitorArgTransformer()]
-        [ArgumentCompleter(typeof(DeviceNameCompleter))]
+        [ArgumentCompleter(typeof(VCPDeviceNameCompleter))]
         [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
         public VCPMonitor[] Monitor { get; set; }
 
-        [Parameter(Mandatory = true, ParameterSetName = "BySource", Position = 1)]
+        [MonitorInputSourceArgTransformer()]
         [ArgumentCompleter(typeof(MonitorInputSourceCompleter))]
-        public string Source { get; set; }
-
-        [Parameter(Mandatory = true, ParameterSetName = "ByValue", Position = 1)]
-        [ArgumentCompleter(typeof(MonitorInputValueCompleter))]
-        public uint Value { get; set; }
+        [Parameter(Mandatory = true, Position = 1)]
+        public uint Source { get; set; }
         #endregion
 
         protected override void ProcessRecord()
         {
-            uint targetValue;
-            if (ParameterSetName.Equals("BySource"))
-            {
-                if (!Enum.TryParse<MonitorInputSource>(Source, true, out MonitorInputSource parsed))
-                {
-                    string validValues = string.Join(", ", Enum.GetNames(typeof(MonitorInputSource)));
-                    ThrowTerminatingError(new ErrorRecord(
-                        new ArgumentException(
-                            $"'{Source}' is not a valid MonitorInputSource. Valid values: {validValues}. " +
-                            "For values outside the MCCS spec (e.g. USB-C), use the -Value parameter instead."),
-                        "InvalidInputSource",
-                        ErrorCategory.InvalidArgument,
-                        Source));
-                    return;
-                }
-                targetValue = (byte)parsed;
-            }
-            else
-            {
-                targetValue = Value;
-            }
-
             foreach (VCPMonitor inputMonitor in Monitor)
             {
                 try
                 {
-                    inputMonitor.SetInputSource(targetValue);
+                    inputMonitor.SetInputSource(Source);
                 }
                 catch (Win32Exception error)
                 {

--- a/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
+++ b/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
@@ -16,15 +16,37 @@ namespace MartinGC94.MonitorConfig.Commands
         public VCPMonitor[] Monitor { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = "BySource", Position = 1)]
-        public MonitorInputSource Source { get; set; }
+        [ArgumentCompleter(typeof(MonitorInputSourceCompleter))]
+        public string Source { get; set; }
 
         [Parameter(Mandatory = true, ParameterSetName = "ByValue", Position = 1)]
+        [ArgumentCompleter(typeof(MonitorInputValueCompleter))]
         public uint Value { get; set; }
         #endregion
 
         protected override void ProcessRecord()
         {
-            uint targetValue = ParameterSetName.Equals("BySource") ? (uint)Source : Value;
+            uint targetValue;
+            if (ParameterSetName.Equals("BySource"))
+            {
+                if (!Enum.TryParse<MonitorInputSource>(Source, true, out MonitorInputSource parsed))
+                {
+                    string validValues = string.Join(", ", Enum.GetNames(typeof(MonitorInputSource)));
+                    ThrowTerminatingError(new ErrorRecord(
+                        new ArgumentException(
+                            $"'{Source}' is not a valid MonitorInputSource. Valid values: {validValues}. " +
+                            "For values outside the MCCS spec (e.g. USB-C), use the -Value parameter instead."),
+                        "InvalidInputSource",
+                        ErrorCategory.InvalidArgument,
+                        Source));
+                    return;
+                }
+                targetValue = (byte)parsed;
+            }
+            else
+            {
+                targetValue = Value;
+            }
 
             foreach (VCPMonitor inputMonitor in Monitor)
             {

--- a/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
+++ b/src/MonitorConfig/Commands/SetMonitorInputCommand.cs
@@ -1,0 +1,46 @@
+using MartinGC94.MonitorConfig.API;
+using MartinGC94.MonitorConfig.API.VCP;
+using System;
+using System.ComponentModel;
+using System.Management.Automation;
+
+namespace MartinGC94.MonitorConfig.Commands
+{
+    [Cmdlet(VerbsCommon.Set, "MonitorInput", DefaultParameterSetName = "BySource")]
+    public sealed class SetMonitorInputCommand : PSCmdlet
+    {
+        #region parameters
+        [MonitorArgTransformer()]
+        [ArgumentCompleter(typeof(DeviceNameCompleter))]
+        [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
+        public VCPMonitor[] Monitor { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = "BySource", Position = 1)]
+        public MonitorInputSource Source { get; set; }
+
+        [Parameter(Mandatory = true, ParameterSetName = "ByValue", Position = 1)]
+        public uint Value { get; set; }
+        #endregion
+
+        protected override void ProcessRecord()
+        {
+            uint targetValue = ParameterSetName.Equals("BySource") ? (uint)Source : Value;
+
+            foreach (VCPMonitor inputMonitor in Monitor)
+            {
+                try
+                {
+                    inputMonitor.SetInputSource(targetValue);
+                }
+                catch (Win32Exception error)
+                {
+                    WriteError(new ErrorRecord(
+                        new Exception($"Failed to set input source due to error: {error.Message}", error),
+                        "SetInputError",
+                        Utils.GetErrorCategory(error),
+                        inputMonitor));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #5

Adds two cmdlets that wrap VCP code 0x60 (Input Select):

- `Get-MonitorInput` — returns a `MonitorInputInfo` with the raw `CurrentValue`, the typed `CurrentSource` (MCCS enum) when applicable, and `PossibleValues` from the monitor's capability string.
- `Set-MonitorInput -Source <UInt32>` — accepts a friendly name (Hdmi1, DisplayPort1, ...), a hex string (0x1B), or a plain numeric value.

## Review feedback addressed (#5)

1. `-Monitor` is `VCPMonitor[]` on both cmdlets, so internal panels managed via WMI get rejected at parameter binding (no WMI-mixed shape, no custom `WMIOptionsSetOnVCPDisplay`-style error needed). A new `VCPDeviceNameCompleter` filters Tab suggestions to VCP-capable displays so a Tab candidate always binds.

2. The original `BySource`/`ByValue` parameter sets are collapsed into a single `-Source <uint>`. The new `MonitorInputSourceArgTransformer` converts MCCS friendly names (case-insensitive) and `0x*` hex strings to uint; plain numeric input still flows through PowerShell's own uint coercion.

3. Friendly names always carry the MCCS number suffix (e.g. `Hdmi1`, `DisplayPort1`).

4. The argument-transformer approach (point 2) covers the string-vs-enum question raised in the original thread.

5. `Get-MonitorInput`'s output object includes `PossibleValues` (byte[]) populated from VCP 0x60 in the DDC/CI capability string. Null when caps are unavailable or don't list VCP 0x60.

## Additional improvements

- Both completers cache results for the lifetime of the PowerShell session and invalidate when the set of logical displays changes (monitor hot-plug). Cached Tab presses avoid Win32 monitor enumeration and DDC/CI capability reads. No wall-clock TTL.
- Added a `MonitorInputInfo` view to `MonitorConfigFormat.ps1xml` so the table output looks consistent (left-aligned `CurrentSource`, auto-width columns).
- Bullet-style description in `Docs/Get-MonitorInput.md` is split into paragraphs so `New-ExternalHelp` renders each bullet on its own line.

## Test plan

- [x] `dotnet build src/MonitorConfig/MonitorConfig.csproj -c Release` is clean (0 warnings, 0 errors).
- [x] `Get-MonitorInput` returns `CurrentValue`/`CurrentSource`/`PossibleValues` against two Dell P2725QE monitors, with `PossibleValues = {15, 17, 27}` matching the capability string (`0x0F`, `0x11`, `0x1B`).
- [x] `Set-MonitorInput -Source Hdmi1` (friendly name), `-Source 17` (decimal), `-Source '0x11'` (hex) all succeed; round-trip writes the current value to avoid losing the calling host's display.
- [x] Tab completion on `-Monitor` shows only VCP-capable `\\.\DISPLAY*` device names; `-Source` suggestions match the values advertised in the capability string (Hdmi1, DisplayPort1, 0x1B for the P2725QE).
- [x] Cache fingerprint test: completer is sub-millisecond after the first call and stays cached after a 7s pause (no wall-clock TTL).
- [x] `Get-Help` on both cmdlets renders SYNOPSIS / SYNTAX / DESCRIPTION / PARAMETERS / 3 EXAMPLES / INPUTS / OUTPUTS correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)